### PR TITLE
Add missing flags for logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,8 +43,6 @@ var (
 	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	sampleExpiry  = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress   = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
-	logLevel      = kingpin.Flag("log.level", "Only log messages with the given severity or above. One of: [debug, info, warn, error, fatal]").Default("info").String()
-	logFormat     = kingpin.Flag("log.format", `Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"`).Default("logger:stderr").String()
 	lastPush      = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",
@@ -250,12 +248,10 @@ func init() {
 }
 
 func main() {
+	log.AddFlags(kingpin.CommandLine)
 	kingpin.Version(version.Print("influxdb_exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
-
-	log.Base().SetLevel(*logLevel)
-	log.Base().SetLevel(*logFormat)
 
 	log.Infoln("Starting influxdb_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ var (
 	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	sampleExpiry  = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress   = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
+	logLevel      = kingpin.Flag("log.level", "Only log messages with the given severity or above. One of: [debug, info, warn, error, fatal]").Default("info").String()
+	logFormat     = kingpin.Flag("log.format", `Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"`).Default("logger:stderr").String()
 	lastPush      = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",
@@ -251,6 +253,9 @@ func main() {
 	kingpin.Version(version.Print("influxdb_exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
+
+	log.Base().SetLevel(*logLevel)
+	log.Base().SetLevel(*logFormat)
 
 	log.Infoln("Starting influxdb_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())

--- a/vendor/github.com/prometheus/common/log/log.go
+++ b/vendor/github.com/prometheus/common/log/log.go
@@ -14,7 +14,6 @@
 package log
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,24 +25,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
-
-type levelFlag string
-
-// String implements flag.Value.
-func (f levelFlag) String() string {
-	return fmt.Sprintf("%q", origLogger.Level.String())
-}
-
-// Set implements flag.Value.
-func (f levelFlag) Set(level string) error {
-	l, err := logrus.ParseLevel(level)
-	if err != nil {
-		return err
-	}
-	origLogger.Level = l
-	return nil
-}
 
 // setSyslogFormatter is nil if the target architecture does not support syslog.
 var setSyslogFormatter func(logger, string, string) error
@@ -55,38 +38,32 @@ func setJSONFormatter() {
 	origLogger.Formatter = &logrus.JSONFormatter{}
 }
 
-type logFormatFlag url.URL
-
-// String implements flag.Value.
-func (f logFormatFlag) String() string {
-	u := url.URL(f)
-	return fmt.Sprintf("%q", u.String())
+type loggerSettings struct {
+	level  string
+	format string
 }
 
-// Set implements flag.Value.
-func (f logFormatFlag) Set(format string) error {
-	return baseLogger.SetFormat(format)
+func (s *loggerSettings) apply(ctx *kingpin.ParseContext) error {
+	err := baseLogger.SetLevel(s.level)
+	if err != nil {
+		return err
+	}
+	err = baseLogger.SetFormat(s.format)
+	return err
 }
 
-func init() {
-	AddFlags(flag.CommandLine)
-}
-
-// AddFlags adds the flags used by this package to the given FlagSet. That's
-// useful if working with a custom FlagSet. The init function of this package
-// adds the flags to flag.CommandLine anyway. Thus, it's usually enough to call
-// flag.Parse() to make the logging flags take effect.
-func AddFlags(fs *flag.FlagSet) {
-	fs.Var(
-		levelFlag(origLogger.Level.String()),
-		"log.level",
-		"Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]",
-	)
-	fs.Var(
-		logFormatFlag(url.URL{Scheme: "logger", Opaque: "stderr"}),
-		"log.format",
-		`Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"`,
-	)
+// AddFlags adds the flags used by this package to the Kingpin application.
+// To use the default Kingpin application, call AddFlags(kingpin.CommandLine)
+func AddFlags(a *kingpin.Application) {
+	s := loggerSettings{}
+	kingpin.Flag("log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]").
+		Default(origLogger.Level.String()).
+		StringVar(&s.level)
+	defaultFormat := url.URL{Scheme: "logger", Opaque: "stderr"}
+	kingpin.Flag("log.format", `Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"`).
+		Default(defaultFormat.String()).
+		StringVar(&s.format)
+	a.Action(s.apply)
 }
 
 // Logger is the interface for loggers used in the Prometheus components.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -83,10 +83,10 @@
 			"revisionTime": "2017-07-07T05:33:19Z"
 		},
 		{
-			"checksumSHA1": "esljoY35OOHttvpjBctA6WGZc70=",
+			"checksumSHA1": "jYpLEs+wZ5LZubvOJEDSQ8I14MI=",
 			"path": "github.com/prometheus/common/log",
-			"revision": "3e6a7635bac6573d43f49f97b47eb9bda195dba8",
-			"revisionTime": "2017-07-07T05:33:19Z"
+			"revision": "8ba51016a21456f1649877d7079f416d69eb3948",
+			"revisionTime": "2017-07-31T09:30:31Z"
 		},
 		{
 			"checksumSHA1": "3VoqH7TFfzA6Ds0zFzIbKCUvBmw=",


### PR DESCRIPTION
When switching to kingpin the logging flags were no longer automatically set, which I missed. This PR adds them back.