### PR TITLE
Added InfluxDB tag 'kind' to affect Prometheus type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ transforms them and exposes them for consumption by Prometheus.
 
 This exporter supports float, int and boolean fields. Tags are converted to Prometheus labels.
 
+It's possible to change the Prometheus type (counter/gauge/untyped) through Influx line protocol tags. See below for a sample REST API call. Be sure to change the time within the default 5m window, or the time range chosen! Time is Unix time in nanoseconds and is the last field.
+
+```bash
+curl -XPOST "http://localhost:9122/write" -d 'cpu,host=server02,kind=gauge,region=useast load=152 1532569820000000000'
+```
+
 The exporter also listens on a UDP socket, port 9122 by default.
 
 ## Alternatives

--- a/main.go
+++ b/main.go
@@ -204,7 +204,6 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 			}
 			sample.ID = fmt.Sprintf("%q", parts)
 
-			fmt.Printf("Sample Kind: %s\n", sample.Kind)
 			c.ch <- sample
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ type influxDBSample struct {
 	Name      string
 	Labels    map[string]string
 	Value     float64
+	Kind      prometheus.ValueType
 	Timestamp time.Time
 }
 
@@ -138,6 +139,7 @@ func (c *influxDBCollector) influxDBPost(w http.ResponseWriter, r *http.Request)
 
 func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 	for _, s := range points {
+
 		fields, err := s.Fields()
 		if err != nil {
 			log.Errorf("error getting fields from point: %s", err)
@@ -172,9 +174,21 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 				Timestamp: s.Time(),
 				Value:     value,
 				Labels:    map[string]string{},
+				Kind:      prometheus.UntypedValue,
 			}
 			for _, v := range s.Tags() {
 				sample.Labels[invalidChars.ReplaceAllString(string(v.Key), "_")] = string(v.Value)
+
+				if string(v.Key) == "kind" {
+					switch string(v.Value) {
+					case "counter":
+						sample.Kind = prometheus.CounterValue
+					case "gauge":
+						sample.Kind = prometheus.GaugeValue
+					default:
+						sample.Kind = prometheus.UntypedValue
+					}
+				}
 			}
 
 			// Calculate a consistent unique ID for the sample.
@@ -190,6 +204,7 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 			}
 			sample.ID = fmt.Sprintf("%q", parts)
 
+			fmt.Printf("Sample Kind: %s\n", sample.Kind)
 			c.ch <- sample
 		}
 	}
@@ -236,7 +251,7 @@ func (c *influxDBCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(sample.Name, "InfluxDB Metric", []string{}, sample.Labels),
-			prometheus.UntypedValue,
+			sample.Kind,
 			sample.Value,
 		)
 	}


### PR DESCRIPTION
Added InfluxDB line protocol tag which affects the chosen Prometheus type for the InfluxDB field. Instead of showing all posted values as Untyped, now you have a choice!