### PR TITLE
Add option for export metric timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DOCKER_IMAGE_NAME ?= influxdb-exporter
+
 include Makefile.common

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ This exporter supports float, int and boolean fields. Tags are converted to Prom
 
 The exporter also listens on a UDP socket, port 9122 by default.
 
+## Timestamps
+
+By default metrics exposed without original timestamps like this:
+
+```
+http_requests_total{method="post",code="200"} 1027
+http_requests_total{method="post",code="400"}    3
+```
+
+If you want to add original timestamps to exposed metrics, please use flag `--timestamps` and metrics will looks like:
+
+```
+http_requests_total{method="post",code="200"} 1027 1395066363000
+http_requests_total{method="post",code="400"}    3 1395066363000
+```
+
 ## Alternatives
 
 If you are sending data to InfluxDB in Graphite or Collectd formats, see the

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	sampleExpiry    = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress     = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
-	exportTimestamp = kingpin.Flag("timestamps", "Export timestamp of points").Bool()
+	exportTimestamp = kingpin.Flag("timestamps", "Export timestamps of points").Bool()
 	lastPush        = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",

--- a/main.go
+++ b/main.go
@@ -39,11 +39,12 @@ const (
 )
 
 var (
-	listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9122").String()
-	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
-	sampleExpiry  = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
-	bindAddress   = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
-	lastPush      = prometheus.NewGauge(
+	listenAddress   = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9122").String()
+	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
+	sampleExpiry    = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
+	bindAddress     = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
+	exportTimestamp = kingpin.Flag("timestamps", "Export timestamp of points").Bool()
+	lastPush        = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",
 			Help: "Unix timestamp of the last received influxdb metrics push in seconds.",
@@ -230,11 +231,17 @@ func (c *influxDBCollector) Collect(ch chan<- prometheus.Metric) {
 		if ageLimit.After(sample.Timestamp) {
 			continue
 		}
-		ch <- prometheus.MustNewConstMetric(
+
+		metric := prometheus.MustNewConstMetric(
 			prometheus.NewDesc(sample.Name, "InfluxDB Metric", []string{}, sample.Labels),
 			prometheus.UntypedValue,
 			sample.Value,
 		)
+
+		if *exportTimestamp {
+			metric = prometheus.NewMetricWithTimestamp(sample.Timestamp, metric)
+		}
+		ch <- metric
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var (
 	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	sampleExpiry    = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress     = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
-	exportTimestamp = kingpin.Flag("timestamps", "Export timestamps of points").Bool()
+	exportTimestamp = kingpin.Flag("timestamps", "Export timestamps of points").Default("false").Bool()
 	lastPush        = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",


### PR DESCRIPTION
Hi

This PR will add support for set timestamp to metrics by add flag `--timestamps`.

This now possible by [#187](https://github.com/prometheus/client_golang/issues/187)