### PR TITLE
Do not run as root by default in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 
 COPY influxdb_exporter /bin/influxdb_exporter
 
+USER        nobody
 EXPOSE      9122
 ENTRYPOINT  [ "/bin/influxdb_exporter" ]


### PR DESCRIPTION
Similar in spirit to prometheus/statsd_exporter#202 and others.

Signed-off-by: Matthias Rampke <mr@soundcloud.com>