### PR TITLE
Add /ping endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,9 +289,16 @@ func main() {
 	go c.serveUdp()
 
 	http.HandleFunc("/write", c.influxDBPost)
+
 	// Some InfluxDB clients try to create a database.
 	http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"results": []}`)
+	})
+
+	// Some InfluxDB clients want to check if the http server is an influx endpoint
+	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		// InfluxDB returns a 204 on success.
+		http.Error(w, "", http.StatusNoContent)
 	})
 
 	http.Handle(*metricsPath, promhttp.Handler())


### PR DESCRIPTION
Some Influx Clients (such as Waystream Devices) use the /ping endpoint to check if the http server is alive and an InfluxDB:
https://docs.influxdata.com/influxdb/v1.7/tools/api/

This Pull requests implements that endpoint.