### PR TITLE
Set expiry to local time instead of received time

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ func (c *influxDBCollector) influxDBPost(w http.ResponseWriter, r *http.Request)
 }
 
 func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
+	currentTime := time.Now()
 	for _, s := range points {
 		fields, err := s.Fields()
 		if err != nil {
@@ -173,7 +174,7 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 			sample := &influxDBSample{
 				Name:          invalidChars.ReplaceAllString(name, "_"),
 				Timestamp:     s.Time(),
-				CollectedTime: time.Now(),
+				CollectedTime: currentTime,
 				Value:         value,
 				Labels:        map[string]string{},
 			}


### PR DESCRIPTION
This PR fixes #61 by storing a local time field `CollectedTime` in the sample. This directs the expiry of the sample instead of the remote time. Due to time drifts and misconfigurations samples could otherwise disappear too early or clobber up the cache.

Cheers