### PR TITLE
decrease memory allocations

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main_test
+package main
 
 import (
 	"fmt"
@@ -44,21 +44,6 @@ func BenchmarkHardcodedReplace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var newString = original
 		ReplaceInvalidChars(&newString)
-	}
-}
-
-// analog of invalidChars = regexp.MustCompile("[^a-zA-Z0-9_]")
-func ReplaceInvalidChars(in *string) {
-
-	for charIndex, char := range *in {
-		charInt := int(char)
-		if !((charInt >= 97 && charInt <= 122) || // a-z
-			(charInt >= 65 && charInt <= 90) || // A-Z
-			(charInt >= 48 && charInt <= 57) || // 0-9
-			charInt == 95) { // _
-
-			*in = (*in)[:charIndex] + "_" + (*in)[charIndex+1:]
-		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,89 @@
+package main_test
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	original = "namespace_pod.container:container_cpu_usage_seconds_total:sum_rate"
+)
+
+var (
+	labels = map[string]string{"name1": "value1", "name2": "value2", "name3": "value3", "name4": "value4"}
+	name   = "name"
+)
+
+func BenchmarkRegexpReplaceInvalid(b *testing.B) {
+	b.ReportAllocs()
+	invalidChars := regexp.MustCompile("[^a-zA-Z0-9_]")
+
+	for i := 0; i < b.N; i++ {
+		invalidChars.ReplaceAllString(original, "_")
+	}
+}
+
+func BenchmarkHardcodedReplace(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var newString = original
+		ReplaceInvalidChars(&newString)
+	}
+}
+
+// analog of invalidChars = regexp.MustCompile("[^a-zA-Z0-9_]")
+func ReplaceInvalidChars(in *string) {
+
+	for charIndex, char := range *in {
+		charInt := int(char)
+		if !((charInt >= 97 && charInt <= 122) || // a-z
+			(charInt >= 65 && charInt <= 90) || // A-Z
+			(charInt >= 48 && charInt <= 57) || // 0-9
+			charInt == 95) { // _
+
+			*in = (*in)[:charIndex] + "_" + (*in)[charIndex+1:]
+		}
+	}
+}
+
+func BenchmarkSprintfArray(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Calculate a consistent unique ID for the sample.
+		labelnames := make([]string, 0, len(labels))
+		for k := range labels {
+			labelnames = append(labelnames, k)
+		}
+		sort.Strings(labelnames)
+		parts := make([]string, 0, len(labels)*2+1)
+		parts = append(parts, name)
+		for _, l := range labelnames {
+			parts = append(parts, l, labels[l])
+		}
+		ID := fmt.Sprintf("%q", parts)
+		ID = ID
+	}
+}
+
+func BenchmarkStringJoin(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+
+		// Calculate a consistent unique ID for the sample.
+		labelnames := make([]string, 0, len(labels))
+		for k := range labels {
+			labelnames = append(labelnames, k)
+		}
+		sort.Strings(labelnames)
+		parts := make([]string, 0, len(labels)*2+1)
+		parts = append(parts, name)
+		for _, l := range labelnames {
+			parts = append(parts, l, labels[l])
+		}
+		ID := strings.Join(parts, ".")
+		ID = ID
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main_test
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -76,8 +76,7 @@ func BenchmarkSprintfArray(b *testing.B) {
 		for _, l := range labelnames {
 			parts = append(parts, l, labels[l])
 		}
-		ID := fmt.Sprintf("%q", parts)
-		ID = ID
+		fmt.Sprintf("%q", parts)
 	}
 }
 
@@ -96,7 +95,6 @@ func BenchmarkStringJoin(b *testing.B) {
 		for _, l := range labelnames {
 			parts = append(parts, l, labels[l])
 		}
-		ID := strings.Join(parts, ".")
-		ID = ID
+		strings.Join(parts, ".")
 	}
 }


### PR DESCRIPTION
We send quite a lot of metrics through the Influxdb_exportor.
It consumes a lot of memory and CPU
Profiling found bottlenecks
 
- replace regexp for replace invalid chars to hardcoded if - decrease 3x memory allocation
- replace sprinf to strings.Join - decrease 3.5x memory allocation

Benchmark resulst:
```
goos: windows
goarch: amd64
pkg: github.com/prometheus/influxdb_exporter
BenchmarkRegexpReplaceInvalid-8           419158              2679 ns/op             339 B/op          6 allocs/op
BenchmarkHardcodedReplace-8              4013084               348 ns/op             240 B/op          3 allocs/op
BenchmarkSprintfArray-8                   363630              2833 ns/op             496 B/op         14 allocs/op
BenchmarkStringJoin-8                    2013498               598 ns/op             304 B/op          4 allocs/op
```
