### PR TITLE
Allow adding prefix to metric name / influx measurement

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,10 +47,10 @@ var (
 	listenAddress       = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9122").String()
 	metricsPath         = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	exporterMetricsPath = kingpin.Flag("web.exporter-telemetry-path", "Path under which to expose exporter metrics.").Default("/metrics/exporter").String()
-	metricPrefix        = kingpin.Flag("metric.prefix", "Prefix Prometheus metrics with this string").Default("").String()
+	metricPrefix        = kingpin.Flag("metric.prefix", "Prefix Prometheus metrics with this string.").Default("").String()
 	sampleExpiry        = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress         = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
-	exportTimestamp     = kingpin.Flag("timestamps", "Export timestamps of points").Default("false").Bool()
+	exportTimestamp     = kingpin.Flag("timestamps", "Export timestamps of points.").Default("false").Bool()
 	lastPush            = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "influxdb_last_push_timestamp_seconds",

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 	listenAddress       = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9122").String()
 	metricsPath         = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	exporterMetricsPath = kingpin.Flag("web.exporter-telemetry-path", "Path under which to expose exporter metrics.").Default("/metrics/exporter").String()
+	metricPrefix        = kingpin.Flag("metric.prefix", "Prefix Prometheus metrics with this string").Default("").String()
 	sampleExpiry        = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress         = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
 	exportTimestamp     = kingpin.Flag("timestamps", "Export timestamps of points").Default("false").Bool()
@@ -171,9 +172,9 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 
 			var name string
 			if field == "value" {
-				name = string(s.Name())
+				name = *metricPrefix + string(s.Name())
 			} else {
-				name = string(s.Name()) + "_" + field
+				name = *metricPrefix + string(s.Name()) + "_" + field
 			}
 
 			ReplaceInvalidChars(&name)

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ var (
 	listenAddress       = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9122").String()
 	metricsPath         = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
 	exporterMetricsPath = kingpin.Flag("web.exporter-telemetry-path", "Path under which to expose exporter metrics.").Default("/metrics/exporter").String()
-	metricPrefix        = kingpin.Flag("metric.prefix", "Prefix Prometheus metrics with this string.").Default("").String()
 	sampleExpiry        = kingpin.Flag("influxdb.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
 	bindAddress         = kingpin.Flag("udp.bind-address", "Address on which to listen for udp packets.").Default(":9122").String()
 	exportTimestamp     = kingpin.Flag("timestamps", "Export timestamps of points.").Default("false").Bool()
@@ -172,9 +171,9 @@ func (c *influxDBCollector) parsePointsToSample(points []models.Point) {
 
 			var name string
 			if field == "value" {
-				name = *metricPrefix + string(s.Name())
+				name = string(s.Name())
 			} else {
-				name = *metricPrefix + string(s.Name()) + "_" + field
+				name = string(s.Name()) + "_" + field
 			}
 
 			ReplaceInvalidChars(&name)
@@ -281,6 +280,10 @@ func ReplaceInvalidChars(in *string) {
 
 			*in = (*in)[:charIndex] + "_" + (*in)[charIndex+1:]
 		}
+	}
+	// prefix with _ if first char is 0-9
+	if int((*in)[0]) >= 48 && int((*in)[0]) <= 57 {
+		*in = "_" + *in
 	}
 }
 


### PR DESCRIPTION
The InfluxDB 'measurement' can have many characters (which are filtered by `ReplaceInvalidChars`). `ReplaceInvalidChars` does not fail (rightly so) if the measurement/name starts with a digit. 

In Prometheus it is not allowed to have a metric which starts with a digit and this Influxdb exporter goes into Panic if a metric start with a digit

```
level=info ts=2020-12-03T20:00:14.160Z caller=main.go:309 msg="Starting influxdb_exporter" version="(version=, branch=, revision=)"
level=info ts=2020-12-03T20:00:14.160Z caller=main.go:310 msg="Build context" context="(go=go1.14.7, user=, date=)"
panic: "302_min" is not a valid metric name

goroutine 46 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
	/home/atze/go/pkg/mod/github.com/prometheus/client_golang@v1.6.0/prometheus/value.go:106
main.(*influxDBCollector).Collect(0xc000122210, 0xc000801020)
	/home/atze/go/src/github.com/prometheus/influxdb_exporter/main.go:254 +0x4ed
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/home/atze/go/pkg/mod/github.com/prometheus/client_golang@v1.6.0/prometheus/registry.go:443 +0x19d
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/home/atze/go/pkg/mod/github.com/prometheus/client_golang@v1.6.0/prometheus/registry.go:535 +0xe36
```

This PR allows the user to add a prefix to the metric name to work around this issue. I could not think of a default replace for a digit or a default prefix, so i guess this is the best solution but options is welcome.

