### PR TITLE
Add v2 write + query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ transforms them and exposes them for consumption by Prometheus.
 
 This exporter supports float, int and boolean fields. Tags are converted to Prometheus labels.
 
-The exporter also listens on a UDP socket, port 9122 by default, where it
-exposes influxDB metrics using `/metrics` endpoint 
+The exporter also listens on a UDP socket, port 9122 by default, as well as the [v2 HTTP endpoints](#v2-support), where it
+exposes InfluxDB metrics using `/metrics` endpoint 
 and exposes exporter's self metrics using `/metrics/exporter` endpoint.
 
 ## Timestamps
@@ -75,6 +75,10 @@ Or if you want to use UDP instead:
 Note that Telegraf already supports outputing Prometheus metrics over HTTP via
 [`outputs.prometheus_client`][telegraf], which avoids having to also run the influxdb_exporter.
 
+## V2 Support
+InfluxDB V2 Support is currently in progress. Supported features include:
+- Querying for a null result
+- Writing data to the exporter - ignores [auth](https://github.com/prometheus/influxdb_exporter/issues/79) and metadata components (org, buckets)
 
 [circleci]: https://circleci.com/gh/prometheus/influxdb_exporter
 [hub]: https://hub.docker.com/r/prom/influxdb-exporter/

--- a/main.go
+++ b/main.go
@@ -352,12 +352,15 @@ func main() {
 	go c.serveUdp()
 
 	http.HandleFunc("/write", c.influxDBPost)
+	http.HandleFunc("/api/v2/write", c.influxDBPost)
 
 	// Some InfluxDB clients try to create a database.
 	http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"results": []}`)
 	})
-
+	http.HandleFunc("/api/v2/query", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, ``)
+	})
 	// Some InfluxDB clients want to check if the http server is an influx endpoint
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		// InfluxDB returns a 204 on success.


### PR DESCRIPTION
I ran into a use case where I needed a v2 client to write to the exporter. Although there might be some endpoints of interest, simply pointing my v2 client at http://localhost:9122 allowed for the metrics to write. One thing to note is this ignores all the token, org, and buckets feature set provided with v2.

Its worth noting the [contributing doc](https://github.com/prometheus/influxdb_exporter/blob/master/CONTRIBUTING.md) didn't specify updating the version file.

Relates #80

@matthiasr