### PR TITLE
scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
-LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+FROM golang:1.17 as builder
+ENV CGO_ENABLED=0  GOARCH=$ARCH GOOS=$OS
 
+WORKDIR /app
+COPY *.go go.mod go.sum /app/
+RUN go mod download
+COPY *.go /app/
+RUN go build -o /app/influxdb_exporter && chmod +x /app/influxdb_exporter
+
+FROM scratch
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 ARG ARCH="amd64"
 ARG OS="linux"
-COPY .build/${OS}-${ARCH}/influxdb_exporter /bin/influxdb_exporter
+COPY --from=builder /app/influxdb_exporter /bin/influxdb_exporter
 
-USER        nobody
 EXPOSE      9122
 ENTRYPOINT  [ "/bin/influxdb_exporter" ]


### PR DESCRIPTION
This is a more opinionated PR but will ensure no other files are in the container but the needed binary. If other binaries are desired, this can just be closed.

@matthiasr 