### PR TITLE
maintainers -> codeowners

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,1 +1,0 @@
-* @matthiasr

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,1 @@
+* Matthias Rampke <mr@soundcloud.com>


### PR DESCRIPTION
This is an opinionated PR, so feel free to close if you disagree. Instead of tagging someone in a description, it would be easier for a contributor to just open the PR, and GitHub will populate the code owners in the PR.

@matthiasr 