### PR TITLE
Add tests for /write HTTP ingestion path

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -14,21 +14,124 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
 	original = "namespace_pod.container:container_cpu_usage_seconds_total:sum_rate"
+
+	// Sample InfluxDB line protocol payload used by the HTTP write tests. The
+	// timestamp is in nanoseconds, matching the default precision used by
+	// influxDBPost when the request omits the "precision" form value.
+	sampleInfluxLine = "weather,location=us-midwest temperature=82 1465839830100400200"
 )
 
 var (
 	labels = map[string]string{"name1": "value1", "name2": "value2", "name3": "value3", "name4": "value4"}
 	name   = "name"
 )
+
+// gzipBytes returns data compressed with the default gzip writer.
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// waitForSamples polls the collector until at least want samples have been
+// processed off the channel into the samples map, or until the deadline.
+func waitForSamples(t *testing.T, c *influxDBCollector, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		got := len(c.samples)
+		c.mu.Unlock()
+		if got >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	c.mu.Lock()
+	got := len(c.samples)
+	c.mu.Unlock()
+	t.Fatalf("timed out waiting for %d samples (got %d)", want, got)
+}
+
+func newTestCollector() *influxDBCollector {
+	return newInfluxDBCollector(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// TestInfluxDBPostGzip verifies that a gzip-compressed line-protocol payload
+// (as sent by Telegraf and other clients with Content-Encoding: gzip) is
+// accepted, decompressed, parsed, and turned into a sample. This is the path
+// originally introduced in #78.
+func TestInfluxDBPostGzip(t *testing.T) {
+	c := newTestCollector()
+
+	body := gzipBytes(t, []byte(sampleInfluxLine))
+	req := httptest.NewRequest(http.MethodPost, "/write", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+
+	c.influxDBPost(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %q)", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	waitForSamples(t, c, 1)
+}
+
+// TestInfluxDBPostUncompressed is the baseline path: the same payload posted
+// without Content-Encoding must also be accepted and produce a sample.
+func TestInfluxDBPostUncompressed(t *testing.T) {
+	c := newTestCollector()
+
+	req := httptest.NewRequest(http.MethodPost, "/write", strings.NewReader(sampleInfluxLine))
+	rr := httptest.NewRecorder()
+
+	c.influxDBPost(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %q)", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	waitForSamples(t, c, 1)
+}
+
+// TestInfluxDBPostGzipMalformed verifies that a request advertising
+// Content-Encoding: gzip but carrying a body that cannot be gunzipped is
+// rejected with a 500 rather than crashing or being treated as plaintext.
+func TestInfluxDBPostGzipMalformed(t *testing.T) {
+	c := newTestCollector()
+
+	req := httptest.NewRequest(http.MethodPost, "/write", strings.NewReader("not actually gzip"))
+	req.Header.Set("Content-Encoding", "gzip")
+	rr := httptest.NewRecorder()
+
+	c.influxDBPost(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (body: %q)", rr.Code, http.StatusInternalServerError, rr.Body.String())
+	}
+}
 
 func BenchmarkRegexpReplaceInvalid(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
Closes #81.

Adds direct test coverage for the three branches of `influxDBCollector.influxDBPost`:

- **gzip-compressed line-protocol body** with `Content-Encoding: gzip`, the path Telegraf and other official InfluxDB clients use. This is the path introduced in #78 and previously had no test coverage, which is what #81 asks for.
- **uncompressed baseline** (no `Content-Encoding`), for parity.
- **malformed gzip body** (`Content-Encoding: gzip` plus a body that does not decompress), to lock in the 500 response so a future refactor cannot silently swallow it as plaintext.

Each test posts a real line-protocol payload through `httptest.NewRecorder` against the existing handler, asserts on the HTTP status, and (for the success cases) waits up to 2 s for `processSamples` to drain the channel into `c.samples` so we exercise the full happy path, not just the HTTP layer.

A couple of small helpers (`gzipBytes`, `waitForSamples`, `newTestCollector`) keep the three tests short and easy to extend with future cases (e.g. the InfluxDB 2.0 / `/api/v2/write` precision variants mentioned in #81 / #80) without adding boilerplate.

### Verification

```
$ GOPROXY=direct go test -count=1 -race ./...
ok  	github.com/prometheus/influxdb_exporter	1.015s

$ GOPROXY=direct go test -v -count=1 -run TestInfluxDBPost ./...
=== RUN   TestInfluxDBPostGzip
--- PASS: TestInfluxDBPostGzip (0.01s)
=== RUN   TestInfluxDBPostUncompressed
--- PASS: TestInfluxDBPostUncompressed (0.00s)
=== RUN   TestInfluxDBPostGzipMalformed
--- PASS: TestInfluxDBPostGzipMalformed (0.00s)
PASS
ok  	github.com/prometheus/influxdb_exporter	0.010s
```

`gofmt -l` is clean. `go vet` reports the same single pre-existing warning on `BenchmarkSprintfArray` (the discarded `fmt.Sprintf` is intentional for that benchmark) on both `main` and this branch — not introduced here.